### PR TITLE
Fix unsubscribe removing unintended listeners

### DIFF
--- a/src/message-hub.ts
+++ b/src/message-hub.ts
@@ -11,8 +11,19 @@ export class MessageHub {
   }
 
   unsubscribe(key: string, listener: Function) {
-    const index = this.listenerLookup[key].indexOf(listener);
-    this.listenerLookup[key].splice(index, 1);
+    const listeners = this.listenerLookup[key];
+    if (!listeners) {
+      return;
+    }
+
+    const index = listeners.indexOf(listener);
+    if (index > -1) {
+      listeners.splice(index, 1);
+
+      if (!listeners.length) {
+        delete this.listenerLookup[key];
+      }
+    }
   }
 
   publish(key: string, ...params: Array<any>) {

--- a/test/general.test.ts
+++ b/test/general.test.ts
@@ -72,6 +72,24 @@ describe('TaskQueue General Operations', () => {
     expect(handler2).not.toHaveBeenCalled;
   });
 
+  it('keeps existing listeners when unsubscribing non-existent handler', async () => {
+    const queue = new TaskQueue({ concurrency: 1 });
+    const handler1 = jest.fn();
+    const handler2 = jest.fn();
+
+    queue.subscribeTaskStatusChange(handler1);
+    queue.subscribeTaskStatusChange(handler2);
+
+    const nonListener = jest.fn();
+    queue.unsubscribeTaskStatusChange(nonListener);
+
+    await queue.addTask(async () => 'test', 'task1');
+
+    expect(handler1).toHaveBeenCalled();
+    expect(handler2).toHaveBeenCalled();
+    expect(nonListener).not.toHaveBeenCalled();
+  });
+
   it('retrieves task information', async () => {
     const queue = new TaskQueue({
       concurrency: 1,


### PR DESCRIPTION
## Summary
- prevent MessageHub.unsubscribe from removing the wrong listener
- add regression test for unsubscribing a non-existent handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896aad17b20832ba720203715b6f9ed